### PR TITLE
Deco coil improvements

### DIFF
--- a/src/main/java/dalapo/factech/auxiliary/Linkable.java
+++ b/src/main/java/dalapo/factech/auxiliary/Linkable.java
@@ -7,5 +7,5 @@ import net.minecraft.world.World;
 
 public interface Linkable
 {
-	public void onLinked(World world, EntityPlayer ep, BlockPos origin, BlockPos thisPos, ItemStack linker);
+	public void onLinked(World world, EntityPlayer ep, BlockPos thisPos, BlockPos otherPos, ItemStack linker);
 }

--- a/src/main/java/dalapo/factech/block/BlockDecoCoil.java
+++ b/src/main/java/dalapo/factech/block/BlockDecoCoil.java
@@ -12,18 +12,19 @@ import net.minecraft.world.World;
 
 public class BlockDecoCoil extends BlockTENoDir implements Linkable
 {
-	public BlockDecoCoil(Material materialIn, String name) {
+	public BlockDecoCoil(Material materialIn, String name)
+	{
 		super(materialIn, name);
-		// TODO Auto-generated constructor stub
 	}
 
 	@Override
-	public void onLinked(World world, EntityPlayer ep, BlockPos origin, BlockPos thisPos, ItemStack linker)
+	public void onLinked(World world, EntityPlayer ep, BlockPos thisPos, BlockPos otherPos, ItemStack linker)
 	{
-		TileEntity te = world.getTileEntity(origin);
-		if (te instanceof TileEntityDecoCoil)
+		TileEntity thisTE = world.getTileEntity(thisPos);
+		TileEntity otherTE = world.getTileEntity(otherPos);
+		if (thisTE instanceof TileEntityDecoCoil && otherTE instanceof TileEntityDecoCoil)
 		{
-			((TileEntityDecoCoil)te).setNeighbour(thisPos);
+			TileEntityDecoCoil.link((TileEntityDecoCoil)thisTE, (TileEntityDecoCoil)otherTE);
 			if (world.isRemote) FacChatHelper.sendChatToPlayer(ep, "Linked!");
 		}
 	}

--- a/src/main/java/dalapo/factech/helper/DecoCoilLink.java
+++ b/src/main/java/dalapo/factech/helper/DecoCoilLink.java
@@ -5,7 +5,13 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
+/**
+ * A visual link between two TileEntityDecoCoils.
+ */
+@SideOnly(Side.CLIENT)
 public class DecoCoilLink {
 
 	private Vec3d start;
@@ -51,7 +57,6 @@ public class DecoCoilLink {
 	public void draw(World world, BufferBuilder buffer, double partialTicks)
 	{
 		buffer.pos(0, 0.1, 0).color(0.5F, 0.5F, 1.0F, 1.0F).endVertex();
-		
 		
 		for (int i=0; i<3; i++)
 		{

--- a/src/main/java/dalapo/factech/helper/DecoCoilLink.java
+++ b/src/main/java/dalapo/factech/helper/DecoCoilLink.java
@@ -1,0 +1,85 @@
+package dalapo.factech.helper;
+
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+
+public class DecoCoilLink {
+
+	private Vec3d start;
+	private Vec3d end;
+	private Vec3d delta;
+	private double distance;
+	private double[][] positions = new double[3][3];
+	private double[][] velocities = new double[3][3];
+	private long[] prevTimes = {0, 0, 0};
+	private double[] targetTimes = {0, 0, 0};
+	
+	public DecoCoilLink(Vec3d startPoint, Vec3d endPoint)
+	{
+		start = startPoint;
+		end = endPoint;
+		delta = end.subtract(start);
+		distance = delta.lengthVector();
+	}
+	
+	public DecoCoilLink(BlockPos startPoint, BlockPos endPoint)
+	{
+		this(new Vec3d(startPoint), new Vec3d(endPoint));
+	}
+
+	public void update(World world)
+	{
+		for (int i=0; i<3; i++)
+		{
+			if (positions[i] == null || world.getTotalWorldTime() - prevTimes[i] >= targetTimes[i])
+			{
+				positions[i] = new double[] {delta.x*0.25*(i+1), delta.y*0.25*(i+1), delta.z*0.25*(i+1)};
+				velocities[i] = new double[] {0, 0, 0};
+				randomOffset(positions[i], MathHelper.sqrt(distance)/20);
+				randomOffset(velocities[i], 0.025);
+				
+				// Reset times
+				prevTimes[i] = world.getTotalWorldTime();
+				targetTimes[i] = (Math.random() + 0.5) * 50.0d;
+			}
+		}
+	}
+	
+	public void draw(World world, BufferBuilder buffer, double partialTicks)
+	{
+		buffer.pos(0, 0.1, 0).color(0.5F, 0.5F, 1.0F, 1.0F).endVertex();
+		
+		
+		for (int i=0; i<3; i++)
+		{
+			double d = ((world.getWorldTime() + targetTimes[i]) % 20) + partialTicks;
+			buffer.pos(positions[i][0] + d*velocities[i][0], positions[i][1] + d*velocities[i][1], positions[i][2] + d*velocities[i][2]).color(0.5F, 0.5F, 1.0F, 1.0F).endVertex();
+		}
+		
+		buffer.pos(delta.x, delta.y, delta.z).color(0.5F, 0.5F, 1.0F, 1.0F).endVertex();
+	}
+	
+	@Override
+	public String toString()
+	{
+		return String.format("DecoCoilLink{start: %s, end: %s}", start, end);
+	}
+	
+	/**
+	 * Adds a random value between -factor and +factor to every value in vec.
+	 * 
+	 * @param vec Array of doubles to add an offset to to affect.
+	 * @param factor Maximum value to offset by.
+	 */
+	private static void randomOffset(double[] vec, double factor)
+	{
+//		Logger.info("Entered randomOffset");
+		for (int i=0; i<vec.length; i++)
+		{
+			vec[i] += (Math.random() - 0.5) * factor * 2;
+		}
+	}
+}

--- a/src/main/java/dalapo/factech/helper/DecoCoilLinkGraph.java
+++ b/src/main/java/dalapo/factech/helper/DecoCoilLinkGraph.java
@@ -1,0 +1,186 @@
+package dalapo.factech.helper;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+
+import dalapo.factech.tileentity.specialized.TileEntityDecoCoil;
+
+public class DecoCoilLinkGraph
+{
+	// Some nifty code simulating "friend" code to allow exclusive access to function in TileEntityDecoCoil - found here:
+	// https://stackoverflow.com/questions/182278/is-there-a-way-to-simulate-the-c-friend-concept-in-java/18634125#18634125
+	public static final class DCLG { private DCLG() {} }
+	private static final DCLG TEDCLINK = new DCLG();
+	
+	private Map<TileEntityDecoCoil, Set<TileEntityDecoCoil> > graph;
+	private Map<Pair<TileEntityDecoCoil, TileEntityDecoCoil>, DecoCoilLink> edgeMap;
+
+	/**
+	 * Constructs an empty graph.
+	 */
+	public DecoCoilLinkGraph()
+	{
+		this.graph = new HashMap<TileEntityDecoCoil, Set<TileEntityDecoCoil> >();
+		this.edgeMap = new HashMap<Pair<TileEntityDecoCoil, TileEntityDecoCoil>, DecoCoilLink>();
+	}
+	
+	/**
+	 * Merges this graph with the other graph provided. Ensures that all TileEntityDecoCoil objects in other
+	 * have their links set to this graph - this ensures that all added objects correctly point to this graph.
+	 * Note that the other graph should no longer be considered to be valid after this point, because
+	 * subsequent calls to this function from that function (e.g. other.merge(evenMoreOther)) would not result
+	 * in other being in a valid state.
+	 * 
+	 * @param other The graph to merge this graph with.
+	 */
+	public void merge(DecoCoilLinkGraph other)
+	{
+		for (TileEntityDecoCoil vertex : other.graph.keySet())
+		{
+			this.addVertex(vertex);
+			for (TileEntityDecoCoil connection : other.graph.get(vertex))
+			{
+				this.addEdge(vertex, connection);
+			}
+			vertex.setLinks(this, TEDCLINK);
+		}
+	}
+	
+	/**
+	 * Adds the given vertex if this doesn't contain the vertex already.
+	 */
+	public void addVertex(TileEntityDecoCoil vertex)
+	{
+		if (vertex != null && !graph.containsKey(vertex))
+		{
+			graph.put(vertex, new HashSet<TileEntityDecoCoil>());
+		}
+	}
+	
+	/**
+	 * Removes all edges containing the given vertex, then removes the vertex.
+	 */
+	public void removeVertex(TileEntityDecoCoil vertex)
+	{
+		Iterable<TileEntityDecoCoil> neighbours = graph.get(vertex);
+		graph.remove(vertex);
+		for (TileEntityDecoCoil connected : neighbours)
+		{
+			removeEdge(vertex, connected);
+		}
+	}
+	
+	/**
+	 * Adds edges/links from first to second and from second to first.
+	 */
+	public void addEdge(TileEntityDecoCoil first, TileEntityDecoCoil second)
+	{
+		if (first == null || second == null || first.equals(second)) return;
+		
+		if (!graph.containsKey(first))
+		{
+			addVertex(first);
+		}
+		if (!graph.containsKey(second))
+		{
+			addVertex(second);
+		}
+		
+		graph.get(first).add(second);
+		graph.get(second).add(first);
+		edgeMap.put(new Pair<TileEntityDecoCoil, TileEntityDecoCoil>(first, second), new DecoCoilLink(first.getPos(), second.getPos()));
+		edgeMap.put(new Pair<TileEntityDecoCoil, TileEntityDecoCoil>(second, first), new DecoCoilLink(second.getPos(), first.getPos()));
+	}
+	
+	/**
+	 * Removes edges/links between first and second, if they exist.
+	 */
+	public void removeEdge(TileEntityDecoCoil first, TileEntityDecoCoil second)
+	{
+    	if (graph.containsKey(first))
+    	{
+    		this.graph.get(first).remove(second);
+    	}
+    	if (graph.containsKey(second))
+    	{
+            this.graph.get(second).remove(first);
+    	}
+		edgeMap.remove(new Pair<TileEntityDecoCoil, TileEntityDecoCoil>(first, second));
+		edgeMap.remove(new Pair<TileEntityDecoCoil, TileEntityDecoCoil>(second, first));
+	}
+	
+	/**
+	 * Returns true if any connected TEDecoCoil is powered (i.e. TileEntityBase.isPowered() is true).
+	 */
+	public boolean isPowered(TileEntityDecoCoil source)
+	{
+		for (TileEntityDecoCoil vertex : getConnectedComponents(source))
+		{
+			if (vertex.isPowered()) return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * Finds and returns all immediate neighbours of the given TileEntityDecoCoil. This takes constant time.
+	 * Returns an empty Iterable if the source is not in the graph or has no neighbours.
+	 * 
+	 * @param source The vertex to look for neighbours of.
+	 * @return An Iterable<TileEntityDecoCoil> of all neighbours of the source. 
+	 */
+	public Iterable<TileEntityDecoCoil> getNeighbours(TileEntityDecoCoil source)
+	{
+		if (graph.containsKey(source)) {
+			return graph.get(source);
+		} else {
+			return new HashSet<TileEntityDecoCoil>();
+		}
+	}
+	
+	/**
+	 * Gets all DecoCoilLinks that originate at the given TileEntityDecoCoil.
+	 * This takes O(E) time, where E is the number of edges (i.e. DecoCoilLink objects).
+	 * Returns an empty Iterable if the source is not in the graph or has no edges originating from it.
+	 * 
+	 * @param source The TileEntityDecoCoil to look for links from.
+	 * @return An iterable list of DecoCoilLinks originating from source.
+	 */
+	public Iterable<DecoCoilLink> getOutgoingLinks(TileEntityDecoCoil source)
+	{
+		Set<DecoCoilLink> links = new HashSet<DecoCoilLink>();
+		for (Pair<TileEntityDecoCoil, TileEntityDecoCoil> edge : edgeMap.keySet())
+		{
+			if (source.equals(edge.a))
+			{
+				links.add(edgeMap.get(edge));
+			}
+		}
+		return links;
+	}
+	
+    public Iterable<TileEntityDecoCoil> getConnectedComponents(TileEntityDecoCoil source)
+    {
+    	Set<TileEntityDecoCoil> checked = new HashSet<TileEntityDecoCoil>();
+    	LinkedList<TileEntityDecoCoil> toCheck = new LinkedList<TileEntityDecoCoil>();
+    	toCheck.add(source);
+    	while (!toCheck.isEmpty())
+    	{
+    		// take first item in list of items to check
+    		TileEntityDecoCoil vertex = toCheck.remove(0);
+        	if (graph.containsKey(vertex)) {
+        		for (TileEntityDecoCoil neighbour : graph.get(vertex))
+        		{
+        			// equals check shouldn't be necessary but w/e
+        			if (!checked.contains(neighbour) && !toCheck.contains(neighbour) && !vertex.equals(neighbour)) {
+        				toCheck.add(neighbour);
+        			}
+        		}
+        	}
+    		checked.add(vertex);
+    	}
+    	return checked;
+    }
+}

--- a/src/main/java/dalapo/factech/helper/DecoCoilLinkGraph.java
+++ b/src/main/java/dalapo/factech/helper/DecoCoilLinkGraph.java
@@ -8,6 +8,17 @@ import java.util.Set;
 
 import dalapo.factech.tileentity.specialized.TileEntityDecoCoil;
 
+/**
+ * A Graph with vertices being TileEntityDecoCoil (TEDC) objects. Edges are defined by an adjacency list,
+ * i.e. each vertex is mapped to a set of other vertices that it is adjacent to.
+ * Additionally, when an edge is created, the pair of vertices used to create the edge are mapped
+ * to a DecoCoilLink, which is a client-side rendering of a link between two TEDC objects.
+ * 
+ * Neighbours of a TEDC can be iterated over using getNeighbours(TEDC).
+ * DecoCoilLink objects originating at a TEDC can be iterated over using getOutgoingLinks(TEDC).
+ * The entire connected component (i.e. all neighbours of neighbours, recursive) of a TEDC can be
+ * iterated over using getConnectedComponent(TEDC).
+ */
 public class DecoCoilLinkGraph
 {
 	// Some nifty code simulating "friend" code to allow exclusive access to function in TileEntityDecoCoil - found here:
@@ -161,6 +172,12 @@ public class DecoCoilLinkGraph
 		return links;
 	}
 	
+	/**
+	 * Gets all TileEntityDecoCoil objects in the connected component of the given TileEntityDecoCoil.
+	 * 
+	 * @param source The TileEntityDecoCoil to get the connected components of.
+	 * @return An Iterable containing each vertex in the connected component originating at the source, including the source.
+	 */
     public Iterable<TileEntityDecoCoil> getConnectedComponents(TileEntityDecoCoil source)
     {
     	Set<TileEntityDecoCoil> checked = new HashSet<TileEntityDecoCoil>();

--- a/src/main/java/dalapo/factech/helper/Pair.java
+++ b/src/main/java/dalapo/factech/helper/Pair.java
@@ -1,5 +1,7 @@
 package dalapo.factech.helper;
 
+import com.google.common.base.Objects;
+
 public class Pair<A,B> {
 	public A a;
 	public B b;
@@ -11,8 +13,30 @@ public class Pair<A,B> {
 	}
 	
 	@Override
+	public int hashCode()
+	{
+		return Objects.hashCode(a, b);
+	}
+	
+	@Override
+	public boolean equals(Object other)
+	{
+		if (other instanceof Pair<?,?>)
+		{
+			if (other == this) return true;
+			
+			Pair<?,?> pair = (Pair<?,?>) other;
+			if (pair.a.equals(this.a) && pair.b.equals(this.b))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	@Override
 	public String toString()
 	{
-		return String.format("{%s, %s}", a, b);
+		return String.format("Pair{%s, %s}", a, b);
 	}
 }

--- a/src/main/java/dalapo/factech/tileentity/TileEntityBase.java
+++ b/src/main/java/dalapo/factech/tileentity/TileEntityBase.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 
 public abstract class TileEntityBase extends TileEntity {
 //	public abstract void sendInfoPacket(EntityPlayer ep);
-	protected boolean isPowered()
+	public boolean isPowered()
 	{
 		return world.isBlockIndirectlyGettingPowered(pos) > 0;
 	}


### PR DESCRIPTION
Deco coils can be linked to an arbitrary number of deco coils, and powering any connected one will disable them all. Deco coils also now damage entities in their path. Do note that it only affects any entities whose hitbox is in the direct line between two un-powered deco coils. This means that baby pigs and such can walk underneath them sometimes. Also, some visual bugs have been fixed with regards to connecting, disconnecting, and removing deco coils.